### PR TITLE
Add "S" prefix to postal code in display only

### DIFF
--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -33,7 +33,7 @@ e.g. typing *`help`* and pressing kbd:[Enter] will open the help window.
 .  Some example commands you can try:
 
 * *`list`* : lists all contacts
-* **`add`**`n/John Doe p/98765432 e/johnd@example.com a/John street, block 123, #01-01` : adds a contact named `John Doe` to the Address Book.
+* **`add`**`n/John Doe p/98765432 e/johnd@example.com a/John street, block 123, #01-01 pc/321123` : adds a contact named `John Doe` to the Address Book.
 * **`delete`**`3` : deletes the 3rd contact shown in the current list
 * *`exit`* : exits the app
 

--- a/src/main/java/seedu/address/model/person/DisplayPostalCode.java
+++ b/src/main/java/seedu/address/model/person/DisplayPostalCode.java
@@ -10,8 +10,8 @@ import static java.util.Objects.requireNonNull;
 public class DisplayPostalCode {
 
     public static final String DISPLAY_POSTAL_CODE_VALIDATION_REGEX = "^S\\d{6}";
-    public static final String MESSAGE_DISPLAY_POSTAL_CODE_CONSTRAINTS = "Display postal code must be an S followed" +
-            "by 6 digits";
+    public static final String MESSAGE_DISPLAY_POSTAL_CODE_CONSTRAINTS = "Display postal code must be an S followed"
+            + "by 6 digits";
     public static final String DISPLAY_PREFIX_POSTAL_CODE = "S";
 
     public final String value;

--- a/src/main/java/seedu/address/model/person/DisplayPostalCode.java
+++ b/src/main/java/seedu/address/model/person/DisplayPostalCode.java
@@ -3,6 +3,10 @@ package seedu.address.model.person;
 import static java.util.Objects.requireNonNull;
 
 //@@author khooroko
+/**
+ * Represents a displayable version of a Person's postal code in the address book.
+ * Guarantees: immutable; is valid as declared in {@link #isValidDisplayPostalCode(String)}
+ */
 public class DisplayPostalCode {
 
     public static final String DISPLAY_POSTAL_CODE_VALIDATION_REGEX = "^S\\d{6}";
@@ -18,7 +22,7 @@ public class DisplayPostalCode {
     public DisplayPostalCode(PostalCode postalCode) {
         requireNonNull(postalCode);
         String displayPostalCode = DISPLAY_PREFIX_POSTAL_CODE + postalCode.toString();
-        if (!displayPostalCode.matches(DISPLAY_POSTAL_CODE_VALIDATION_REGEX)) {
+        if (isValidDisplayPostalCode(displayPostalCode)) {
             throw new AssertionError(MESSAGE_DISPLAY_POSTAL_CODE_CONSTRAINTS);
         }
         this.value = displayPostalCode;

--- a/src/main/java/seedu/address/model/person/DisplayPostalCode.java
+++ b/src/main/java/seedu/address/model/person/DisplayPostalCode.java
@@ -1,0 +1,44 @@
+package seedu.address.model.person;
+
+import static java.util.Objects.requireNonNull;
+
+//@@author khooroko
+public class DisplayPostalCode {
+
+    public static final String POSTAL_CODE_VALIDATION_REGEX = "^S\\d{6}";
+    public static final String MESSAGE_DISPLAY_POSTAL_CODE_CONSTRAINTS = "Display postal code must be an S followed" +
+            "by 6 digits";
+    public static final String DISPLAY_PREFIX_POSTAL_CODE = "S";
+
+    public final String value;
+
+    /**
+     * Creates a display only postal code from the given postal code.
+     */
+    public DisplayPostalCode(PostalCode postalCode) {
+        requireNonNull(postalCode);
+        String displayPostalCode = DISPLAY_PREFIX_POSTAL_CODE + postalCode.toString();
+        if (!displayPostalCode.matches(POSTAL_CODE_VALIDATION_REGEX)) {
+            throw new AssertionError(MESSAGE_DISPLAY_POSTAL_CODE_CONSTRAINTS);
+        }
+        this.value = displayPostalCode;
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof PostalCode // instanceof handles nulls
+                && this.value.equals(((PostalCode) other).value)); // state check
+    }
+
+    @Override
+    public int hashCode() {
+        return value.hashCode();
+    }
+
+}

--- a/src/main/java/seedu/address/model/person/DisplayPostalCode.java
+++ b/src/main/java/seedu/address/model/person/DisplayPostalCode.java
@@ -5,7 +5,7 @@ import static java.util.Objects.requireNonNull;
 //@@author khooroko
 public class DisplayPostalCode {
 
-    public static final String POSTAL_CODE_VALIDATION_REGEX = "^S\\d{6}";
+    public static final String DISPLAY_POSTAL_CODE_VALIDATION_REGEX = "^S\\d{6}";
     public static final String MESSAGE_DISPLAY_POSTAL_CODE_CONSTRAINTS = "Display postal code must be an S followed" +
             "by 6 digits";
     public static final String DISPLAY_PREFIX_POSTAL_CODE = "S";
@@ -18,10 +18,17 @@ public class DisplayPostalCode {
     public DisplayPostalCode(PostalCode postalCode) {
         requireNonNull(postalCode);
         String displayPostalCode = DISPLAY_PREFIX_POSTAL_CODE + postalCode.toString();
-        if (!displayPostalCode.matches(POSTAL_CODE_VALIDATION_REGEX)) {
+        if (!displayPostalCode.matches(DISPLAY_POSTAL_CODE_VALIDATION_REGEX)) {
             throw new AssertionError(MESSAGE_DISPLAY_POSTAL_CODE_CONSTRAINTS);
         }
         this.value = displayPostalCode;
+    }
+
+    /**
+     * Returns true if a given string is a valid person postal code.
+     */
+    public static boolean isValidDisplayPostalCode(String test) {
+        return test.matches(DISPLAY_POSTAL_CODE_VALIDATION_REGEX);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -23,6 +23,7 @@ public class Person implements ReadOnlyPerson {
     private ObjectProperty<Email> email;
     private ObjectProperty<Address> address;
     private ObjectProperty<PostalCode> postalCode;
+    private ObjectProperty<DisplayPostalCode> displayPostalCode;
 
     private ObjectProperty<UniqueTagList> tags;
 
@@ -36,6 +37,7 @@ public class Person implements ReadOnlyPerson {
         this.email = new SimpleObjectProperty<>(email);
         this.address = new SimpleObjectProperty<>(address);
         this.postalCode = new SimpleObjectProperty<>(postalCode);
+        this.displayPostalCode = new SimpleObjectProperty<>(new DisplayPostalCode(postalCode));
         // protect internal tags from changes in the arg list
         this.tags = new SimpleObjectProperty<>(new UniqueTagList(tags));
     }
@@ -117,6 +119,16 @@ public class Person implements ReadOnlyPerson {
     @Override
     public PostalCode getPostalCode() {
         return postalCode.get();
+    }
+
+    @Override
+    public ObjectProperty<DisplayPostalCode> displayPostalCodeProperty() {
+        return displayPostalCode;
+    }
+
+    @Override
+    public DisplayPostalCode getDisplayPostalCode() {
+        return displayPostalCode.get();
     }
 
     //@@author

--- a/src/main/java/seedu/address/model/person/ReadOnlyPerson.java
+++ b/src/main/java/seedu/address/model/person/ReadOnlyPerson.java
@@ -22,6 +22,8 @@ public interface ReadOnlyPerson {
     Address getAddress();
     ObjectProperty<PostalCode> postalCodeProperty();
     PostalCode getPostalCode();
+    ObjectProperty<DisplayPostalCode> displayPostalCodeProperty();
+    DisplayPostalCode getDisplayPostalCode();
     ObjectProperty<UniqueTagList> tagProperty();
     Set<Tag> getTags();
 

--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -46,7 +46,7 @@ public class PersonCard extends UiPart<Region> {
     @FXML
     private Label address;
     @FXML
-    private Label postalCode;
+    private Label displayPostalCode;
     @FXML
     private Label email;
     @FXML
@@ -69,7 +69,7 @@ public class PersonCard extends UiPart<Region> {
         name.textProperty().bind(Bindings.convert(person.nameProperty()));
         phone.textProperty().bind(Bindings.convert(person.phoneProperty()));
         address.textProperty().bind(Bindings.convert(person.addressProperty()));
-        postalCode.textProperty().bind(Bindings.convert(person.postalCodeProperty()));
+        displayPostalCode.textProperty().bind(Bindings.convert(person.displayPostalCodeProperty()));
         email.textProperty().bind(Bindings.convert(person.emailProperty()));
         person.tagProperty().addListener((observable, oldValue, newValue) -> {
             tags.getChildren().clear();

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -30,7 +30,7 @@
       <FlowPane fx:id="tags" />
       <Label fx:id="phone" styleClass="cell_small_label" text="\$phone" />
       <Label fx:id="address" styleClass="cell_small_label" text="\$address" />
-      <Label fx:id="postalCode" styleClass="cell_small_label" text="\$postalCode" />
+      <Label fx:id="displayPostalCode" styleClass="cell_small_label" text="\$displayPostalCode" />
       <Label fx:id="email" styleClass="cell_small_label" text="\$email" />
     </VBox>
   </GridPane>

--- a/src/test/java/seedu/address/model/person/DisplayPostalCodeTest.java
+++ b/src/test/java/seedu/address/model/person/DisplayPostalCodeTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 
+//@@author khooroko
 public class DisplayPostalCodeTest {
 
     @Test

--- a/src/test/java/seedu/address/model/person/DisplayPostalCodeTest.java
+++ b/src/test/java/seedu/address/model/person/DisplayPostalCodeTest.java
@@ -1,0 +1,22 @@
+package seedu.address.model.person;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class DisplayPostalCodeTest {
+
+    @Test
+    public void isValidDisplayPostalCode() {
+        // invalid displayPostalCodees
+        assertFalse(DisplayPostalCode.isValidDisplayPostalCode("")); // empty string
+        assertFalse(DisplayPostalCode.isValidDisplayPostalCode(" ")); // spaces only
+        assertFalse(DisplayPostalCode.isValidDisplayPostalCode("123456")); // numbers only
+
+        // valid displayPostalCodees
+        assertTrue(DisplayPostalCode.isValidDisplayPostalCode("S000000"));
+        assertTrue(DisplayPostalCode.isValidDisplayPostalCode("S999999"));
+        assertTrue(DisplayPostalCode.isValidDisplayPostalCode("S123456"));
+    }
+}


### PR DESCRIPTION
Adding and editing untouched.
"S" will only be there when viewed in UI.
This is achieved by creating a DisplayPostalCode class.