### PR TITLE
Display postal code prefix

### DIFF
--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -33,7 +33,7 @@ e.g. typing *`help`* and pressing kbd:[Enter] will open the help window.
 .  Some example commands you can try:
 
 * *`list`* : lists all contacts
-* **`add`**`n/John Doe p/98765432 e/johnd@example.com a/John street, block 123, #01-01` : adds a contact named `John Doe` to the Address Book.
+* **`add`**`n/John Doe p/98765432 e/johnd@example.com a/John street, block 123, #01-01 pc/321123` : adds a contact named `John Doe` to the Address Book.
 * **`delete`**`3` : deletes the 3rd contact shown in the current list
 * *`exit`* : exits the app
 

--- a/src/main/java/seedu/address/model/person/DisplayPostalCode.java
+++ b/src/main/java/seedu/address/model/person/DisplayPostalCode.java
@@ -43,8 +43,8 @@ public class DisplayPostalCode {
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
-                || (other instanceof PostalCode // instanceof handles nulls
-                && this.value.equals(((PostalCode) other).value)); // state check
+                || (other instanceof DisplayPostalCode // instanceof handles nulls
+                && this.value.equals(((DisplayPostalCode) other).value)); // state check
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/DisplayPostalCode.java
+++ b/src/main/java/seedu/address/model/person/DisplayPostalCode.java
@@ -1,0 +1,44 @@
+package seedu.address.model.person;
+
+import static java.util.Objects.requireNonNull;
+
+//@@author khooroko
+public class DisplayPostalCode {
+
+    public static final String POSTAL_CODE_VALIDATION_REGEX = "^S\\d{6}";
+    public static final String MESSAGE_DISPLAY_POSTAL_CODE_CONSTRAINTS = "Display postal code must be an S followed" +
+            "by 6 digits";
+    public static final String DISPLAY_PREFIX_POSTAL_CODE = "S";
+
+    public final String value;
+
+    /**
+     * Creates a display only postal code from the given postal code.
+     */
+    public DisplayPostalCode(PostalCode postalCode) {
+        requireNonNull(postalCode);
+        String displayPostalCode = DISPLAY_PREFIX_POSTAL_CODE + postalCode.toString();
+        if (!displayPostalCode.matches(POSTAL_CODE_VALIDATION_REGEX)) {
+            throw new AssertionError(MESSAGE_DISPLAY_POSTAL_CODE_CONSTRAINTS);
+        }
+        this.value = displayPostalCode;
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof PostalCode // instanceof handles nulls
+                && this.value.equals(((PostalCode) other).value)); // state check
+    }
+
+    @Override
+    public int hashCode() {
+        return value.hashCode();
+    }
+
+}

--- a/src/main/java/seedu/address/model/person/DisplayPostalCode.java
+++ b/src/main/java/seedu/address/model/person/DisplayPostalCode.java
@@ -5,7 +5,7 @@ import static java.util.Objects.requireNonNull;
 //@@author khooroko
 public class DisplayPostalCode {
 
-    public static final String POSTAL_CODE_VALIDATION_REGEX = "^S\\d{6}";
+    public static final String DISPLAY_POSTAL_CODE_VALIDATION_REGEX = "^S\\d{6}";
     public static final String MESSAGE_DISPLAY_POSTAL_CODE_CONSTRAINTS = "Display postal code must be an S followed" +
             "by 6 digits";
     public static final String DISPLAY_PREFIX_POSTAL_CODE = "S";
@@ -18,10 +18,17 @@ public class DisplayPostalCode {
     public DisplayPostalCode(PostalCode postalCode) {
         requireNonNull(postalCode);
         String displayPostalCode = DISPLAY_PREFIX_POSTAL_CODE + postalCode.toString();
-        if (!displayPostalCode.matches(POSTAL_CODE_VALIDATION_REGEX)) {
+        if (!displayPostalCode.matches(DISPLAY_POSTAL_CODE_VALIDATION_REGEX)) {
             throw new AssertionError(MESSAGE_DISPLAY_POSTAL_CODE_CONSTRAINTS);
         }
         this.value = displayPostalCode;
+    }
+
+    /**
+     * Returns true if a given string is a valid person postal code.
+     */
+    public static boolean isValidDisplayPostalCode(String test) {
+        return test.matches(DISPLAY_POSTAL_CODE_VALIDATION_REGEX);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -172,7 +172,7 @@ public class Person implements ReadOnlyPerson {
     @Override
     public int hashCode() {
         // use this method for custom fields hashing instead of implementing your own
-        return Objects.hash(name, phone, email, address, postalCode, debt, tags);
+        return Objects.hash(name, phone, email, address, postalCode, displayPostalCode, debt, tags);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -123,6 +123,11 @@ public class Person implements ReadOnlyPerson {
         return displayPostalCode;
     }
 
+    @Override
+    public DisplayPostalCode getDisplayPostalCode() {
+        return displayPostalCode.get();
+    }
+
     public void setDebt(Debt debt) {
         this.debt.set(requireNonNull(debt));
     }

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -23,6 +23,7 @@ public class Person implements ReadOnlyPerson {
     private ObjectProperty<Email> email;
     private ObjectProperty<Address> address;
     private ObjectProperty<PostalCode> postalCode;
+    private ObjectProperty<DisplayPostalCode> displayPostalCode;
 
     private ObjectProperty<UniqueTagList> tags;
 
@@ -36,6 +37,7 @@ public class Person implements ReadOnlyPerson {
         this.email = new SimpleObjectProperty<>(email);
         this.address = new SimpleObjectProperty<>(address);
         this.postalCode = new SimpleObjectProperty<>(postalCode);
+        this.displayPostalCode = new SimpleObjectProperty<>(new DisplayPostalCode(postalCode));
         // protect internal tags from changes in the arg list
         this.tags = new SimpleObjectProperty<>(new UniqueTagList(tags));
     }
@@ -117,6 +119,16 @@ public class Person implements ReadOnlyPerson {
     @Override
     public PostalCode getPostalCode() {
         return postalCode.get();
+    }
+
+    @Override
+    public ObjectProperty<DisplayPostalCode> displayPostalCodeProperty() {
+        return displayPostalCode;
+    }
+
+    @Override
+    public DisplayPostalCode getDisplayPostalCode() {
+        return displayPostalCode.get();
     }
 
     //@@author

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -114,11 +114,6 @@ public class Person implements ReadOnlyPerson {
     }
 
     @Override
-    public ObjectProperty<PostalCode> postalCodeProperty() {
-        return postalCode;
-    }
-
-    @Override
     public PostalCode getPostalCode() {
         return postalCode.get();
     }
@@ -126,11 +121,6 @@ public class Person implements ReadOnlyPerson {
     @Override
     public ObjectProperty<DisplayPostalCode> displayPostalCodeProperty() {
         return displayPostalCode;
-    }
-
-    @Override
-    public DisplayPostalCode getDisplayPostalCode() {
-        return displayPostalCode.get();
     }
 
     public void setDebt(Debt debt) {

--- a/src/main/java/seedu/address/model/person/ReadOnlyPerson.java
+++ b/src/main/java/seedu/address/model/person/ReadOnlyPerson.java
@@ -22,6 +22,7 @@ public interface ReadOnlyPerson {
     Address getAddress();
     PostalCode getPostalCode();
     ObjectProperty<DisplayPostalCode> displayPostalCodeProperty();
+    DisplayPostalCode getDisplayPostalCode();
     ObjectProperty<Debt> debtProperty();
     Debt getDebt();
     ObjectProperty<UniqueTagList> tagProperty();

--- a/src/main/java/seedu/address/model/person/ReadOnlyPerson.java
+++ b/src/main/java/seedu/address/model/person/ReadOnlyPerson.java
@@ -22,6 +22,8 @@ public interface ReadOnlyPerson {
     Address getAddress();
     ObjectProperty<PostalCode> postalCodeProperty();
     PostalCode getPostalCode();
+    ObjectProperty<DisplayPostalCode> displayPostalCodeProperty();
+    DisplayPostalCode getDisplayPostalCode();
     ObjectProperty<UniqueTagList> tagProperty();
     Set<Tag> getTags();
 

--- a/src/main/java/seedu/address/model/person/ReadOnlyPerson.java
+++ b/src/main/java/seedu/address/model/person/ReadOnlyPerson.java
@@ -20,10 +20,8 @@ public interface ReadOnlyPerson {
     Email getEmail();
     ObjectProperty<Address> addressProperty();
     Address getAddress();
-    ObjectProperty<PostalCode> postalCodeProperty();
     PostalCode getPostalCode();
     ObjectProperty<DisplayPostalCode> displayPostalCodeProperty();
-    DisplayPostalCode getDisplayPostalCode();
     ObjectProperty<Debt> debtProperty();
     Debt getDebt();
     ObjectProperty<UniqueTagList> tagProperty();

--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -46,7 +46,7 @@ public class PersonCard extends UiPart<Region> {
     @FXML
     private Label address;
     @FXML
-    private Label postalCode;
+    private Label displayPostalCode;
     @FXML
     private Label email;
     @FXML
@@ -69,7 +69,7 @@ public class PersonCard extends UiPart<Region> {
         name.textProperty().bind(Bindings.convert(person.nameProperty()));
         phone.textProperty().bind(Bindings.convert(person.phoneProperty()));
         address.textProperty().bind(Bindings.convert(person.addressProperty()));
-        postalCode.textProperty().bind(Bindings.convert(person.postalCodeProperty()));
+        displayPostalCode.textProperty().bind(Bindings.convert(person.displayPostalCodeProperty()));
         email.textProperty().bind(Bindings.convert(person.emailProperty()));
         person.tagProperty().addListener((observable, oldValue, newValue) -> {
             tags.getChildren().clear();

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -30,7 +30,7 @@
       <FlowPane fx:id="tags" />
       <Label fx:id="phone" styleClass="cell_small_label" text="\$phone" />
       <Label fx:id="address" styleClass="cell_small_label" text="\$address" />
-      <Label fx:id="postalCode" styleClass="cell_small_label" text="\$postalCode" />
+      <Label fx:id="displayPostalCode" styleClass="cell_small_label" text="\$displayPostalCode" />
       <Label fx:id="email" styleClass="cell_small_label" text="\$email" />
     </VBox>
   </GridPane>

--- a/src/test/java/guitests/guihandles/PersonCardHandle.java
+++ b/src/test/java/guitests/guihandles/PersonCardHandle.java
@@ -16,7 +16,8 @@ public class PersonCardHandle extends NodeHandle<Node> {
     private static final String ADDRESS_FIELD_ID = "#address";
     private static final String PHONE_FIELD_ID = "#phone";
     private static final String EMAIL_FIELD_ID = "#email";
-    private static final String POSTAL_CODE_FIELD_ID = "#postalCode";
+    private static final String DISPLAY_POSTAL_CODE_FIELD_ID = "#displayPostalCode";
+    private static final String DEBT_FIELD_ID = "#debt";
     private static final String TAGS_FIELD_ID = "#tags";
 
     private final Label idLabel;
@@ -24,7 +25,8 @@ public class PersonCardHandle extends NodeHandle<Node> {
     private final Label addressLabel;
     private final Label phoneLabel;
     private final Label emailLabel;
-    private final Label postalCodeLabel;
+    private final Label displayPostalCodeLabel;
+    private final Label debtLabel;
     private final List<Label> tagLabels;
 
     public PersonCardHandle(Node cardNode) {
@@ -35,7 +37,8 @@ public class PersonCardHandle extends NodeHandle<Node> {
         this.addressLabel = getChildNode(ADDRESS_FIELD_ID);
         this.phoneLabel = getChildNode(PHONE_FIELD_ID);
         this.emailLabel = getChildNode(EMAIL_FIELD_ID);
-        this.postalCodeLabel = getChildNode(POSTAL_CODE_FIELD_ID);
+        this.displayPostalCodeLabel = getChildNode(DISPLAY_POSTAL_CODE_FIELD_ID);
+        this.debtLabel = getChildNode(DEBT_FIELD_ID);
 
         Region tagsContainer = getChildNode(TAGS_FIELD_ID);
         this.tagLabels = tagsContainer
@@ -65,8 +68,12 @@ public class PersonCardHandle extends NodeHandle<Node> {
         return emailLabel.getText();
     }
 
-    public String getPostalCode() {
-        return  postalCodeLabel.getText();
+    public String getDisplayPostalCode() {
+        return  displayPostalCodeLabel.getText();
+    }
+
+    public String getDebt() {
+        return debtLabel.getText();
     }
 
     public List<String> getTags() {

--- a/src/test/java/seedu/address/model/person/DisplayPostalCodeTest.java
+++ b/src/test/java/seedu/address/model/person/DisplayPostalCodeTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 
+//@@author khooroko
 public class DisplayPostalCodeTest {
 
     @Test

--- a/src/test/java/seedu/address/model/person/DisplayPostalCodeTest.java
+++ b/src/test/java/seedu/address/model/person/DisplayPostalCodeTest.java
@@ -1,0 +1,22 @@
+package seedu.address.model.person;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class DisplayPostalCodeTest {
+
+    @Test
+    public void isValidDisplayPostalCode() {
+        // invalid displayPostalCodees
+        assertFalse(DisplayPostalCode.isValidDisplayPostalCode("")); // empty string
+        assertFalse(DisplayPostalCode.isValidDisplayPostalCode(" ")); // spaces only
+        assertFalse(DisplayPostalCode.isValidDisplayPostalCode("123456")); // numbers only
+
+        // valid displayPostalCodees
+        assertTrue(DisplayPostalCode.isValidDisplayPostalCode("S000000"));
+        assertTrue(DisplayPostalCode.isValidDisplayPostalCode("S999999"));
+        assertTrue(DisplayPostalCode.isValidDisplayPostalCode("S123456"));
+    }
+}

--- a/src/test/java/seedu/address/ui/testutil/GuiTestAssert.java
+++ b/src/test/java/seedu/address/ui/testutil/GuiTestAssert.java
@@ -23,6 +23,8 @@ public class GuiTestAssert {
         assertEquals(expectedCard.getEmail(), actualCard.getEmail());
         assertEquals(expectedCard.getName(), actualCard.getName());
         assertEquals(expectedCard.getPhone(), actualCard.getPhone());
+        assertEquals(expectedCard.getDisplayPostalCode(), actualCard.getDisplayPostalCode());
+        assertEquals(expectedCard.getDebt(), actualCard.getDebt());
         assertEquals(expectedCard.getTags(), actualCard.getTags());
     }
 
@@ -34,6 +36,8 @@ public class GuiTestAssert {
         assertEquals(expectedPerson.getPhone().value, actualCard.getPhone());
         assertEquals(expectedPerson.getEmail().value, actualCard.getEmail());
         assertEquals(expectedPerson.getAddress().value, actualCard.getAddress());
+        assertEquals(expectedPerson.getDisplayPostalCode().value, actualCard.getDisplayPostalCode());
+        assertEquals(expectedPerson.getDebt().value, actualCard.getDebt());
         assertEquals(expectedPerson.getTags().stream().map(tag -> tag.tagName).collect(Collectors.toList()),
                 actualCard.getTags());
     }


### PR DESCRIPTION
On display, postal codes have S in front (e.g. "S321123"), but commands only need the numbers.