### PR TITLE
DarkTheme.css: fix white screen when no person card is displayed

### DIFF
--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -90,6 +90,7 @@
 .list-view {
     -fx-background-insets: 0;
     -fx-padding: 0;
+    -fx-background-color: derive(#1d1d1d, 20%);
 }
 
 .list-cell {


### PR DESCRIPTION
Fix white screen when no person card is displayed (when `find `command returns no result and when the address book is cleared) as per [issue ](https://github.com/nus-cs2103-AY1718S1/forum/issues/86)mentioned in Slack.