### PR TITLE
Fix select command behaviour

### DIFF
--- a/src/main/java/seedu/address/ui/NearbyPersonListPanel.java
+++ b/src/main/java/seedu/address/ui/NearbyPersonListPanel.java
@@ -72,12 +72,6 @@ public class NearbyPersonListPanel extends UiPart<Region> {
         });
     }
 
-    @Subscribe
-    private void handleJumpToListRequestEvent(JumpToListRequestEvent event) {
-        logger.info(LogsCenter.getEventHandlingLogMessage(event));
-        scrollTo(event.targetIndex);
-    }
-
     /**
      * Custom {@code ListCell} that displays the graphics of a {@code PersonCard}.
      */

--- a/src/main/java/seedu/address/ui/NearbyPersonListPanel.java
+++ b/src/main/java/seedu/address/ui/NearbyPersonListPanel.java
@@ -6,8 +6,6 @@ import java.util.logging.Logger;
 
 import org.fxmisc.easybind.EasyBind;
 
-import com.google.common.eventbus.Subscribe;
-
 import javafx.application.Platform;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
@@ -16,7 +14,6 @@ import javafx.scene.control.ListCell;
 import javafx.scene.control.ListView;
 import javafx.scene.layout.Region;
 import seedu.address.commons.core.LogsCenter;
-import seedu.address.commons.events.ui.JumpToListRequestEvent;
 import seedu.address.commons.events.ui.NearbyPersonPanelSelectionChangedEvent;
 import seedu.address.model.person.ReadOnlyPerson;
 

--- a/src/test/java/seedu/address/ui/NearbyPersonListPanelTest.java
+++ b/src/test/java/seedu/address/ui/NearbyPersonListPanelTest.java
@@ -57,15 +57,4 @@ public class NearbyPersonListPanelTest extends GuiUnitTest {
         assertCardDisplaysPerson(expectedPerson, actualCard);
         assertEquals(Integer.toString(1) + ". ", actualCard.getId());
     }
-
-    @Test
-    public void handleJumpToListRequestEvent() {
-        postNow(JUMP_TO_SECOND_EVENT);
-        guiRobot.pauseForHuman();
-
-        PersonCardHandle expectedCard = nearbyPersonListPanelHandle
-                .getPersonCardHandle(INDEX_SECOND_PERSON.getZeroBased());
-        PersonCardHandle selectedCard = nearbyPersonListPanelHandle.getHandleToSelectedCard();
-        assertCardEquals(expectedCard, selectedCard);
-    }
 }

--- a/src/test/java/seedu/address/ui/NearbyPersonListPanelTest.java
+++ b/src/test/java/seedu/address/ui/NearbyPersonListPanelTest.java
@@ -1,13 +1,11 @@
 package seedu.address.ui;
 
 import static org.junit.Assert.assertEquals;
-import static seedu.address.testutil.EventsUtil.postNow;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
 import static seedu.address.testutil.TypicalPersons.BENSON;
 import static seedu.address.testutil.TypicalPersons.CARL;
 import static seedu.address.testutil.TypicalPersons.getTypicalPersons;
 import static seedu.address.ui.testutil.GuiTestAssert.assertCardDisplaysPerson;
-import static seedu.address.ui.testutil.GuiTestAssert.assertCardEquals;
 
 import org.junit.Before;
 import org.junit.Test;


### PR DESCRIPTION
Previously using select would bug out and go to the nearby person's details instead (e.g. select 1 (Alex) then select 2 would show Roy instead of Bernice)