### PR TITLE
Trivial changes to borrow command implementation

### DIFF
--- a/src/main/java/seedu/address/logic/commands/BorrowCommand.java
+++ b/src/main/java/seedu/address/logic/commands/BorrowCommand.java
@@ -48,8 +48,6 @@ public class BorrowCommand extends UndoableCommand {
             model.addDebtToPerson(personThatBorrowed, amount);
         } catch (PersonNotFoundException pnfe) {
             assert false : "The target person cannot be missing";
-        } catch (IllegalValueException ive) {
-            throw new CommandException(Debt.MESSAGE_DEBT_CONSTRAINTS);
         }
 
         return new CommandResult(String.format(MESSAGE_BORROW_SUCCESS, personThatBorrowed.getName(), amount));

--- a/src/main/java/seedu/address/logic/commands/BorrowCommand.java
+++ b/src/main/java/seedu/address/logic/commands/BorrowCommand.java
@@ -4,7 +4,6 @@ import java.util.List;
 
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
-import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.person.Debt;
 import seedu.address.model.person.ReadOnlyPerson;

--- a/src/main/java/seedu/address/logic/parser/BorrowCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/BorrowCommandParser.java
@@ -14,7 +14,7 @@ import seedu.address.model.person.Debt;
  */
 public class BorrowCommandParser implements Parser<BorrowCommand> {
 
-    // index and debt amount borrowed
+    // arguments: index and debt amount borrowed
     private static final int ARGS_LENGTH = 2;
 
     @Override

--- a/src/main/java/seedu/address/logic/parser/BorrowCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/BorrowCommandParser.java
@@ -9,6 +9,7 @@ import seedu.address.logic.commands.BorrowCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.Debt;
 
+//@@author jelneo
 /**
  * Parses input arguments and creates a new BorrowCommand object
  */

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -247,7 +247,6 @@ public class AddressBook implements ReadOnlyAddressBook {
      * @param amount amount that the person borrowed. Must be either a positive integer or positive number with
      *               two decimal places
      * @throws PersonNotFoundException if {@code target} could not be found in the list.
-     * @throws IllegalValueException if new {@code Debt} object could not be created.
      */
     public void addDebtToPerson(ReadOnlyPerson target, Debt amount) throws PersonNotFoundException {
         Person editedPerson = new Person(target);

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -249,8 +249,7 @@ public class AddressBook implements ReadOnlyAddressBook {
      * @throws PersonNotFoundException if {@code target} could not be found in the list.
      * @throws IllegalValueException if new {@code Debt} object could not be created.
      */
-    public void addDebtToPerson(ReadOnlyPerson target, Debt amount) throws PersonNotFoundException,
-            IllegalValueException {
+    public void addDebtToPerson(ReadOnlyPerson target, Debt amount) throws PersonNotFoundException {
         Person editedPerson = new Person(target);
 
         try {

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -257,7 +257,7 @@ public class AddressBook implements ReadOnlyAddressBook {
             persons.setPerson(target, editedPerson);
         } catch (DuplicatePersonException dpe) {
             assert false : "There should be no duplicate when updating the debt of a person";
-        } catch (IllegalValueException e) {
+        } catch (IllegalValueException ive) {
             assert false : "New debt amount should not be invalid since amount and debt field in target have "
                     + "been validated";
         }

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -102,5 +102,6 @@ public interface Model {
      * Increase the debt of a person by the amount indicated
      * @throws PersonNotFoundException if {@code target} could not be found in the list.
      */
-    void addDebtToPerson(ReadOnlyPerson target, Debt amount) throws PersonNotFoundException, IllegalValueException;
+    void addDebtToPerson(ReadOnlyPerson target, Debt amount) throws PersonNotFoundException;
+
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -209,11 +209,9 @@ public class ModelManager extends ComponentManager implements Model {
      * @param amount amount that the person borrowed. Must be either a positive integer or positive number with
      *               two decimal places
      * @throws PersonNotFoundException if {@code target} could not be found in the list.
-     * @throws IllegalValueException if {@code amount} is invalid.
      */
     @Override
-    public void addDebtToPerson(ReadOnlyPerson target, Debt amount) throws PersonNotFoundException,
-            IllegalValueException {
+    public void addDebtToPerson(ReadOnlyPerson target, Debt amount) throws PersonNotFoundException {
         addressBook.addDebtToPerson(target, amount);
         indicateAddressBookChanged();
     }

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -14,7 +14,6 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import javafx.collections.ObservableList;
-import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.logic.CommandHistory;
 import seedu.address.logic.Password;
 import seedu.address.logic.UndoRedoStack;
@@ -195,8 +194,7 @@ public class AddCommandTest {
         }
 
         @Override
-        public void addDebtToPerson(ReadOnlyPerson target, Debt amount) throws PersonNotFoundException,
-                IllegalValueException {
+        public void addDebtToPerson(ReadOnlyPerson target, Debt amount) throws PersonNotFoundException {
             fail("This method should not be called.");
         }
 

--- a/src/test/java/seedu/address/logic/parser/BorrowCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/BorrowCommandParserTest.java
@@ -8,20 +8,20 @@ import org.junit.Test;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.exceptions.IllegalValueException;
-import seedu.address.logic.commands.PaybackCommand;
+import seedu.address.logic.commands.BorrowCommand;
 import seedu.address.model.person.Debt;
 
 //@@author jelneo
 public class BorrowCommandParserTest {
 
     private static final String MESSAGE_INVALID_FORMAT =  String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-            PaybackCommand.MESSAGE_USAGE);
+            BorrowCommand.MESSAGE_USAGE);
     private static final String VALID_DEBT_FIGURE = "500.20";
     private static final String INVALID_DEBT_FIGURE = "-500";
     private static final String VALID_INDEX = "1";
     private static final String INVALID_INDEX = "-1";
 
-    private PaybackCommandParser parser  = new PaybackCommandParser();
+    private BorrowCommandParser parser  = new BorrowCommandParser();
 
     @Test
     public void parse_missingParts_failure() {
@@ -49,14 +49,13 @@ public class BorrowCommandParserTest {
 
     @Test
     public void parse_validArguments() {
-        Index index = Index.fromOneBased(Integer.valueOf(VALID_INDEX));
-        Debt amount = null;
         try {
-            amount = new Debt(VALID_DEBT_FIGURE);
+            Index index = Index.fromOneBased(Integer.valueOf(VALID_INDEX));
+            Debt amount = new Debt(VALID_DEBT_FIGURE);
+            BorrowCommand expectedBorrowCommand = new BorrowCommand(index, amount);
+            assertParseSuccess(parser, VALID_INDEX + " " + VALID_DEBT_FIGURE, expectedBorrowCommand);
         } catch (IllegalValueException ive) {
             ive.printStackTrace();
         }
-        PaybackCommand expectedPaybackCommand = new PaybackCommand(index, amount);
-        assertParseSuccess(parser, VALID_INDEX + " " + VALID_DEBT_FIGURE, expectedPaybackCommand);
     }
 }

--- a/src/test/java/seedu/address/logic/parser/BorrowCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/BorrowCommandParserTest.java
@@ -1,0 +1,62 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import org.junit.Test;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.logic.commands.PaybackCommand;
+import seedu.address.model.person.Debt;
+
+//@@author jelneo
+public class BorrowCommandParserTest {
+
+    private static final String MESSAGE_INVALID_FORMAT =  String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+            PaybackCommand.MESSAGE_USAGE);
+    private static final String VALID_DEBT_FIGURE = "500.20";
+    private static final String INVALID_DEBT_FIGURE = "-500";
+    private static final String VALID_INDEX = "1";
+    private static final String INVALID_INDEX = "-1";
+
+    private PaybackCommandParser parser  = new PaybackCommandParser();
+
+    @Test
+    public void parse_missingParts_failure() {
+        // no index specified
+        assertParseFailure(parser, VALID_DEBT_FIGURE, MESSAGE_INVALID_FORMAT);
+
+        // no debt amount specified
+        assertParseFailure(parser, VALID_INDEX, MESSAGE_INVALID_FORMAT);
+
+        // no index and no field specified
+        assertParseFailure(parser, "", MESSAGE_INVALID_FORMAT);
+    }
+
+    @Test
+    public void parse_invalidArguments() {
+        // invalid index and amount
+        assertParseFailure(parser, INVALID_INDEX + " " + INVALID_DEBT_FIGURE, MESSAGE_INVALID_FORMAT);
+
+        // valid index but invalid amount
+        assertParseFailure(parser, VALID_INDEX + " " + INVALID_DEBT_FIGURE, MESSAGE_INVALID_FORMAT);
+
+        // invalid index but valid amount
+        assertParseFailure(parser, INVALID_INDEX + " " + VALID_DEBT_FIGURE, MESSAGE_INVALID_FORMAT);
+    }
+
+    @Test
+    public void parse_validArguments() {
+        Index index = Index.fromOneBased(Integer.valueOf(VALID_INDEX));
+        Debt amount = null;
+        try {
+            amount = new Debt(VALID_DEBT_FIGURE);
+        } catch (IllegalValueException ive) {
+            ive.printStackTrace();
+        }
+        PaybackCommand expectedPaybackCommand = new PaybackCommand(index, amount);
+        assertParseSuccess(parser, VALID_INDEX + " " + VALID_DEBT_FIGURE, expectedPaybackCommand);
+    }
+}


### PR DESCRIPTION
Remove unnecessary exceptions for borrow command
Rename parameter in `catch `statement
add `BorrowCommandParserTest.java`