### PR TITLE
Change result display to show 4 lines when maximised

### DIFF
--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -30,8 +30,8 @@
     </padding>
   </StackPane>
 
-  <StackPane VBox.vgrow="NEVER" fx:id="resultDisplayPlaceholder" styleClass="pane-with-border"
-      minHeight="100" prefHeight="100" maxHeight="100">
+  <StackPane fx:id="resultDisplayPlaceholder" styleClass="pane-with-border"
+      minHeight="80" prefHeight="130">
     <padding>
       <Insets top="5" right="10" bottom="5" left="10" />
     </padding>


### PR DESCRIPTION
2 lines when at minimum window size as defined by current preferences.

Rationale for this is because invalid format message for edit, find and sort etc are 4 lines