### PR TITLE
Fix bug #218: borrow/payback only works once

### DIFF
--- a/src/main/java/seedu/address/logic/commands/UndoableCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UndoableCommand.java
@@ -71,7 +71,9 @@ public abstract class UndoableCommand extends Command {
     @Override
     public final CommandResult execute() throws CommandException {
         saveAddressBookSnapshot();
-        EventsCenter.getInstance().post(new JumpToListRequestEvent(index));
+        if (index != null) {
+            EventsCenter.getInstance().post(new JumpToListRequestEvent(index));
+        }
         return executeUndoableCommand();
     }
 }

--- a/src/main/java/seedu/address/logic/commands/UndoableCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UndoableCommand.java
@@ -71,6 +71,7 @@ public abstract class UndoableCommand extends Command {
     @Override
     public final CommandResult execute() throws CommandException {
         saveAddressBookSnapshot();
+        EventsCenter.getInstance().post(new JumpToListRequestEvent(index));
         return executeUndoableCommand();
     }
 }

--- a/src/test/java/guitests/guihandles/PersonListPanelHandle.java
+++ b/src/test/java/guitests/guihandles/PersonListPanelHandle.java
@@ -126,6 +126,18 @@ public class PersonListPanelHandle extends NodeHandle<ListView<PersonCard>> {
     }
 
     /**
+     * Returns true if the selected {@code PersonCard} is different from the value remembered by the most recent
+     * {@code rememberSelectedPersonCard()} call.
+     */
+    public boolean isSelectedPersonCardChanged(Object other) {
+        if (!(other instanceof PersonListPanelHandle)) {
+            throw new AssertionError("Wrong object passed in");
+        }
+        PersonListPanelHandle personListPanelHandle = (PersonListPanelHandle) other;
+        return getSelectedCardIndex() == personListPanelHandle.getSelectedCardIndex();
+    }
+
+    /**
      * Returns the size of the list.
      */
     public int getListSize() {

--- a/src/test/java/systemtests/AddressBookSystemTest.java
+++ b/src/test/java/systemtests/AddressBookSystemTest.java
@@ -185,9 +185,9 @@ public abstract class AddressBookSystemTest {
      * {@code expectedSelectedCardIndex}, and only the card at {@code expectedSelectedCardIndex} is selected.
      * @see PersonListPanelHandle#isSelectedPersonCardChanged()
      */
-    protected void assertSelectedCardChanged(Index expectedSelectedCardIndex) {
+    protected void assertSelectedCardChanged() {
         assertTrue(getInfoPanel().isSelectedPersonChanged());
-        assertEquals(expectedSelectedCardIndex.getZeroBased(), getPersonListPanel().getSelectedCardIndex());
+        assertTrue(mainWindowHandle.getPersonListPanel().isSelectedPersonCardChanged());
     }
 
     /**
@@ -197,7 +197,7 @@ public abstract class AddressBookSystemTest {
      */
     protected void assertSelectedCardUnchanged() {
         assertFalse(getInfoPanel().isSelectedPersonChanged());
-        assertFalse(getPersonListPanel().isSelectedPersonCardChanged());
+        assertTrue(getPersonListPanel().isSelectedPersonCardChanged(mainWindowHandle.getPersonListPanel()));
     }
 
     /**

--- a/src/test/java/systemtests/DeleteCommandSystemTest.java
+++ b/src/test/java/systemtests/DeleteCommandSystemTest.java
@@ -13,6 +13,7 @@ import static seedu.address.testutil.TypicalPersons.KEYWORD_MATCHING_MEIER;
 
 import org.junit.Test;
 
+import guitests.GuiRobot;
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.DeleteCommand;
@@ -163,7 +164,7 @@ public class DeleteCommandSystemTest extends AddressBookSystemTest {
      * Performs the same verification as {@code assertCommandSuccess(String, Model, String)} except that the browser url
      * and selected card are expected to update accordingly depending on the card at {@code expectedSelectedCardIndex}.
      * @see DeleteCommandSystemTest#assertCommandSuccess(String, Model, String)
-     * @see AddressBookSystemTest#assertSelectedCardChanged(Index)
+     * @see AddressBookSystemTest#assertSelectedCardChanged()
      */
     private void assertCommandSuccess(String command, Model expectedModel, String expectedResultMessage,
             Index expectedSelectedCardIndex) {
@@ -171,7 +172,8 @@ public class DeleteCommandSystemTest extends AddressBookSystemTest {
         assertApplicationDisplaysExpected("", expectedResultMessage, expectedModel);
 
         if (expectedSelectedCardIndex != null) {
-            assertSelectedCardChanged(expectedSelectedCardIndex);
+            GuiRobot guiRobot = new GuiRobot();
+            assertSelectedCardChanged();
         } else {
             assertSelectedCardUnchanged();
         }

--- a/src/test/java/systemtests/EditCommandSystemTest.java
+++ b/src/test/java/systemtests/EditCommandSystemTest.java
@@ -338,7 +338,7 @@ public class EditCommandSystemTest extends AddressBookSystemTest {
      * Verifications 1 to 3 are performed by
      * {@code AddressBookSystemTest#assertApplicationDisplaysExpected(String, String, Model)}.<br>
      * @see AddressBookSystemTest#assertApplicationDisplaysExpected(String, String, Model)
-     * @see AddressBookSystemTest#assertSelectedCardChanged(Index)
+     * @see AddressBookSystemTest#assertSelectedCardChanged()
      */
     private void assertCommandSuccess(String command, Model expectedModel, String expectedResultMessage,
             Index expectedSelectedCardIndex) {
@@ -347,7 +347,7 @@ public class EditCommandSystemTest extends AddressBookSystemTest {
         assertApplicationDisplaysExpected("", expectedResultMessage, expectedModel);
         assertCommandBoxShowsDefaultStyle();
         if (expectedSelectedCardIndex != null) {
-            assertSelectedCardChanged(expectedSelectedCardIndex);
+            assertSelectedCardChanged();
         } else {
             assertSelectedCardUnchanged();
         }

--- a/src/test/java/systemtests/SelectCommandSystemTest.java
+++ b/src/test/java/systemtests/SelectCommandSystemTest.java
@@ -103,7 +103,7 @@ public class SelectCommandSystemTest extends AddressBookSystemTest {
      * browser url and selected card will be verified if the current selected card and the card at
      * {@code expectedSelectedCardIndex} are different.
      * @see AddressBookSystemTest#assertApplicationDisplaysExpected(String, String, Model)
-     * @see AddressBookSystemTest#assertSelectedCardChanged(Index)
+     * @see AddressBookSystemTest#assertSelectedCardChanged()
      */
     private void assertCommandSuccess(String command, Index expectedSelectedCardIndex) {
         Model expectedModel = getModel();
@@ -117,7 +117,7 @@ public class SelectCommandSystemTest extends AddressBookSystemTest {
         if (preExecutionSelectedCardIndex == expectedSelectedCardIndex.getZeroBased()) {
             assertSelectedCardUnchanged();
         } else {
-            assertSelectedCardChanged(expectedSelectedCardIndex);
+            assertSelectedCardChanged();
         }
 
         assertCommandBoxShowsDefaultStyle();


### PR DESCRIPTION
Previously sometimes calling commands will cause the selected person to be deselected