### PR TITLE
Sort by deadline now places blacklisted people with 0 debts at the bottom

### DIFF
--- a/src/main/java/seedu/address/model/person/UniquePersonList.java
+++ b/src/main/java/seedu/address/model/person/UniquePersonList.java
@@ -144,7 +144,8 @@ public class UniquePersonList implements Iterable<Person> {
             break;
         case "deadline":
             internalList.sort((Person p1, Person p2) -> p1.getDeadline().compareTo(p2.getDeadline()));
-            internalList.sort((Person p1, Person p2) -> Boolean.compare(p1.isWhitelisted(), p2.isWhitelisted()));
+            internalList.sort((Person p1, Person p2) -> Boolean.compare(p1.getDebt().toNumber() == 0,
+                    p2.getDebt().toNumber() == 0));
             break;
         default:
             throw new IllegalArgumentException("Invalid sort ordering");


### PR DESCRIPTION
Previously blacklisted persons with 0 debt were still sorted on top. Deadline logically should not matter if debt is 0